### PR TITLE
修复 PropTypes isRequired 报错，connect 第二个参数不支持对象和不能通过npm repo labrador-redux 访问 repository的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "index.js",
   "scripts": {
   },
+  "repository": {
+    "url": "https://github.com/maichong/labrador-redux"
+  },
   "author": {
     "email": "li@maichong.it",
     "name": "li",

--- a/src/util/wrapActionCreators.js
+++ b/src/util/wrapActionCreators.js
@@ -1,0 +1,5 @@
+import { bindActionCreators } from 'redux'
+
+export default function wrapActionCreators(actionCreators) {
+  return dispatch => bindActionCreators(actionCreators, dispatch)
+}


### PR DESCRIPTION
- 修复组件第一次加载时如果 PropTypes isRequired 会报错 组件"XXX"的必要属性"xx"缺失，得到"undefined"
- connect 是第二个参数不支持对象
- 不能通过npm repo labrador-redux 访问 repository